### PR TITLE
SCAN Text and Data Changes

### DIFF
--- a/Assets/Scenes/Mission1.unity
+++ b/Assets/Scenes/Mission1.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.4465782, g: 0.49641252, b: 0.5748167, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -670,6 +670,7 @@ MonoBehaviour:
   mushroom3: {fileID: 74241104}
   mushroom4: {fileID: 0}
   mushroom5: {fileID: 0}
+  berry1: {fileID: 0}
   audio: {fileID: 1317985352}
   thePlayer: {fileID: 1816455746}
   interactText: {fileID: 7728793724725410581}
@@ -684,9 +685,25 @@ MeshCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Convex: 0
+  m_Convex: 1
   m_CookingOptions: 14
   m_Mesh: {fileID: 7682724294687611154, guid: 205a0a0b80e4dab49bb26c9a39a6fca9, type: 3}
+--- !u!54 &74241110
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 74241104}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 126
+  m_CollisionDetection: 0
 --- !u!1 &91549233
 GameObject:
   m_ObjectHideFlags: 0
@@ -14905,7 +14922,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh20090
+  m_Name: pb_Mesh24960
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -20118,7 +20135,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh18972
+  m_Name: pb_Mesh23756
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -23418,6 +23435,7 @@ MonoBehaviour:
   mushroom3: {fileID: 0}
   mushroom4: {fileID: 0}
   mushroom5: {fileID: 0}
+  berry1: {fileID: 0}
   audio: {fileID: 1317985352}
   thePlayer: {fileID: 1816455746}
   interactText: {fileID: 7728793724725410581}
@@ -23432,9 +23450,25 @@ MeshCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Convex: 0
+  m_Convex: 1
   m_CookingOptions: 14
   m_Mesh: {fileID: 7682724294687611154, guid: 205a0a0b80e4dab49bb26c9a39a6fca9, type: 3}
+--- !u!54 &917231928
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 917231922}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 126
+  m_CollisionDetection: 0
 --- !u!1 &940992721 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: -4366817407545858016, guid: d479326d256e0fd40ac5546cd7a8f4b6,
@@ -25136,8 +25170,8 @@ GameObject:
   - component: {fileID: 1041846807}
   - component: {fileID: 1041846806}
   - component: {fileID: 1041846805}
-  - component: {fileID: 1041846804}
   - component: {fileID: 1041846808}
+  - component: {fileID: 1041846804}
   m_Layer: 0
   m_Name: LandingSite_SCAN
   m_TagString: Untagged
@@ -25159,8 +25193,8 @@ Transform:
   m_Father: {fileID: 2014056843}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!64 &1041846804
-MeshCollider:
+--- !u!65 &1041846804
+BoxCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -25169,10 +25203,9 @@ MeshCollider:
   m_Material: {fileID: 0}
   m_IsTrigger: 1
   m_Enabled: 1
-  serializedVersion: 3
-  m_Convex: 1
-  m_CookingOptions: 14
-  m_Mesh: {fileID: 629367185}
+  serializedVersion: 2
+  m_Size: {x: 46, y: 15, z: 36.000004}
+  m_Center: {x: 23, y: 7.5, z: -18.00049}
 --- !u!114 &1041846805
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -25446,16 +25479,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e90e8421b6c909345b184d0a996f7e39, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  courtyardTrigger: {fileID: 1041846802}
-  mazeTrigger: {fileID: 1796003607}
-  forestTrigger: {fileID: 2142837772}
-  labHUBTrigger: {fileID: 1877903990}
-  templeInteriorTrigger: {fileID: 1115351871}
-  isInCourtyard: 1
-  isInMaze: 0
-  isInForest: 0
-  isInLabHUB: 0
-  isInTemple: 0
+  displayScanDevice: 1
+  scanAreaTextToDisplay: Landing Site
   scanDevice: {fileID: 1348592515}
   remainingSamplesText: {fileID: 461430149}
   scanDeviceDisplay: {fileID: 1505127163}
@@ -26362,16 +26387,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e90e8421b6c909345b184d0a996f7e39, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  courtyardTrigger: {fileID: 1041846802}
-  mazeTrigger: {fileID: 1796003607}
-  forestTrigger: {fileID: 2142837772}
-  labHUBTrigger: {fileID: 1877903990}
-  templeInteriorTrigger: {fileID: 1115351871}
-  isInCourtyard: 0
-  isInMaze: 0
-  isInForest: 0
-  isInLabHUB: 0
-  isInTemple: 1
+  displayScanDevice: 1
+  scanAreaTextToDisplay: Example Area
   scanDevice: {fileID: 1348592515}
   remainingSamplesText: {fileID: 461430149}
   scanDeviceDisplay: {fileID: 1505127163}
@@ -32905,6 +32922,7 @@ MonoBehaviour:
   mushroom3: {fileID: 0}
   mushroom4: {fileID: 0}
   mushroom5: {fileID: 0}
+  berry1: {fileID: 0}
   audio: {fileID: 1317985352}
   thePlayer: {fileID: 1816455746}
   interactText: {fileID: 7728793724725410581}
@@ -32919,9 +32937,25 @@ MeshCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Convex: 0
+  m_Convex: 1
   m_CookingOptions: 14
   m_Mesh: {fileID: 7682724294687611154, guid: 205a0a0b80e4dab49bb26c9a39a6fca9, type: 3}
+--- !u!54 &1267295552
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1267295546}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 126
+  m_CollisionDetection: 0
 --- !u!1 &1274062037
 GameObject:
   m_ObjectHideFlags: 0
@@ -34380,7 +34414,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh19660
+  m_Name: pb_Mesh24452
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -38753,8 +38787,8 @@ GameObject:
   - component: {fileID: 1796003612}
   - component: {fileID: 1796003611}
   - component: {fileID: 1796003610}
-  - component: {fileID: 1796003609}
   - component: {fileID: 1796003613}
+  - component: {fileID: 1796003609}
   m_Layer: 0
   m_Name: Maze_SCAN
   m_TagString: Untagged
@@ -38776,8 +38810,8 @@ Transform:
   m_Father: {fileID: 2014056843}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!64 &1796003609
-MeshCollider:
+--- !u!65 &1796003609
+BoxCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -38786,10 +38820,9 @@ MeshCollider:
   m_Material: {fileID: 0}
   m_IsTrigger: 1
   m_Enabled: 1
-  serializedVersion: 3
-  m_Convex: 1
-  m_CookingOptions: 14
-  m_Mesh: {fileID: 1461492721}
+  serializedVersion: 2
+  m_Size: {x: 31, y: 16, z: 30}
+  m_Center: {x: 26.5, y: 8, z: -21}
 --- !u!114 &1796003610
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -39071,16 +39104,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e90e8421b6c909345b184d0a996f7e39, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  courtyardTrigger: {fileID: 1041846802}
-  mazeTrigger: {fileID: 1796003607}
-  forestTrigger: {fileID: 2142837772}
-  labHUBTrigger: {fileID: 1877903990}
-  templeInteriorTrigger: {fileID: 1115351871}
-  isInCourtyard: 0
-  isInMaze: 1
-  isInForest: 0
-  isInLabHUB: 0
-  isInTemple: 0
+  displayScanDevice: 1
+  scanAreaTextToDisplay: Maze Area
   scanDevice: {fileID: 1348592515}
   remainingSamplesText: {fileID: 461430149}
   scanDeviceDisplay: {fileID: 1505127163}
@@ -39882,16 +39907,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e90e8421b6c909345b184d0a996f7e39, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  courtyardTrigger: {fileID: 1041846802}
-  mazeTrigger: {fileID: 1796003607}
-  forestTrigger: {fileID: 2142837772}
-  labHUBTrigger: {fileID: 1877903990}
-  templeInteriorTrigger: {fileID: 1115351871}
-  isInCourtyard: 0
-  isInMaze: 0
-  isInForest: 0
-  isInLabHUB: 1
-  isInTemple: 0
+  displayScanDevice: 0
+  scanAreaTextToDisplay: Example Area
   scanDevice: {fileID: 1348592515}
   remainingSamplesText: {fileID: 461430149}
   scanDeviceDisplay: {fileID: 1505127163}
@@ -45289,6 +45306,61 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 868635763}
     m_Modifications:
+    - target: {fileID: -4216859302048453862, guid: 0bac9ebca891b454bb2913f9205a68eb,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.3851695
+      objectReference: {fileID: 0}
+    - target: {fileID: -4216859302048453862, guid: 0bac9ebca891b454bb2913f9205a68eb,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -43.09836
+      objectReference: {fileID: 0}
+    - target: {fileID: -4216859302048453862, guid: 0bac9ebca891b454bb2913f9205a68eb,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2.571289
+      objectReference: {fileID: 0}
+    - target: {fileID: -4216859302048453862, guid: 0bac9ebca891b454bb2913f9205a68eb,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -4216859302048453862, guid: 0bac9ebca891b454bb2913f9205a68eb,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -4216859302048453862, guid: 0bac9ebca891b454bb2913f9205a68eb,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: -4216859302048453862, guid: 0bac9ebca891b454bb2913f9205a68eb,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -4216859302048453862, guid: 0bac9ebca891b454bb2913f9205a68eb,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: -4216859302048453862, guid: 0bac9ebca891b454bb2913f9205a68eb,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -4216859302048453862, guid: 0bac9ebca891b454bb2913f9205a68eb,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -4216859302048453862, guid: 0bac9ebca891b454bb2913f9205a68eb,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: -927199367670048503, guid: 0bac9ebca891b454bb2913f9205a68eb,
         type: 3}
       propertyPath: m_Name
@@ -45373,61 +45445,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 3.5766602
-      objectReference: {fileID: 0}
-    - target: {fileID: -4216859302048453862, guid: 0bac9ebca891b454bb2913f9205a68eb,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 2.3851695
-      objectReference: {fileID: 0}
-    - target: {fileID: -4216859302048453862, guid: 0bac9ebca891b454bb2913f9205a68eb,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -43.09836
-      objectReference: {fileID: 0}
-    - target: {fileID: -4216859302048453862, guid: 0bac9ebca891b454bb2913f9205a68eb,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -2.571289
-      objectReference: {fileID: 0}
-    - target: {fileID: -4216859302048453862, guid: 0bac9ebca891b454bb2913f9205a68eb,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: -4216859302048453862, guid: 0bac9ebca891b454bb2913f9205a68eb,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: -4216859302048453862, guid: 0bac9ebca891b454bb2913f9205a68eb,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: -4216859302048453862, guid: 0bac9ebca891b454bb2913f9205a68eb,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: -4216859302048453862, guid: 0bac9ebca891b454bb2913f9205a68eb,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: -4216859302048453862, guid: 0bac9ebca891b454bb2913f9205a68eb,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -4216859302048453862, guid: 0bac9ebca891b454bb2913f9205a68eb,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -4216859302048453862, guid: 0bac9ebca891b454bb2913f9205a68eb,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -3199376690798021666, guid: 0bac9ebca891b454bb2913f9205a68eb,
         type: 3}
@@ -52828,6 +52845,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: Mushroom4
       objectReference: {fileID: 0}
+    - target: {fileID: -927199367670048503, guid: 205a0a0b80e4dab49bb26c9a39a6fca9,
+        type: 3}
+      propertyPath: m_TagString
+      value: Pickup
+      objectReference: {fileID: 0}
     - target: {fileID: -4216859302048453862, guid: 205a0a0b80e4dab49bb26c9a39a6fca9,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -52950,6 +52972,7 @@ MonoBehaviour:
   mushroom3: {fileID: 0}
   mushroom4: {fileID: 2081429227}
   mushroom5: {fileID: 0}
+  berry1: {fileID: 0}
   audio: {fileID: 1317985352}
   thePlayer: {fileID: 1816455746}
   interactText: {fileID: 7728793724725410581}
@@ -52964,9 +52987,25 @@ MeshCollider:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Convex: 0
+  m_Convex: 1
   m_CookingOptions: 14
   m_Mesh: {fileID: 7682724294687611154, guid: 205a0a0b80e4dab49bb26c9a39a6fca9, type: 3}
+--- !u!54 &2081429232
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2081429227}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 126
+  m_CollisionDetection: 0
 --- !u!1 &2091612503
 GameObject:
   m_ObjectHideFlags: 0
@@ -53640,8 +53679,8 @@ GameObject:
   - component: {fileID: 2142837777}
   - component: {fileID: 2142837776}
   - component: {fileID: 2142837775}
-  - component: {fileID: 2142837774}
   - component: {fileID: 2142837778}
+  - component: {fileID: 2142837774}
   m_Layer: 0
   m_Name: Forest_SCAN
   m_TagString: Untagged
@@ -53663,8 +53702,8 @@ Transform:
   m_Father: {fileID: 2014056843}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!64 &2142837774
-MeshCollider:
+--- !u!65 &2142837774
+BoxCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -53673,10 +53712,9 @@ MeshCollider:
   m_Material: {fileID: 0}
   m_IsTrigger: 1
   m_Enabled: 1
-  serializedVersion: 3
-  m_Convex: 1
-  m_CookingOptions: 14
-  m_Mesh: {fileID: 574019176}
+  serializedVersion: 2
+  m_Size: {x: 37.999996, y: 16, z: 42}
+  m_Center: {x: 26.999998, y: 8, z: -20}
 --- !u!114 &2142837775
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -53950,16 +53988,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e90e8421b6c909345b184d0a996f7e39, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  courtyardTrigger: {fileID: 1041846802}
-  mazeTrigger: {fileID: 1796003607}
-  forestTrigger: {fileID: 2142837772}
-  labHUBTrigger: {fileID: 1877903990}
-  templeInteriorTrigger: {fileID: 1115351871}
-  isInCourtyard: 0
-  isInMaze: 0
-  isInForest: 1
-  isInLabHUB: 0
-  isInTemple: 0
+  displayScanDevice: 1
+  scanAreaTextToDisplay: Forest
   scanDevice: {fileID: 1348592515}
   remainingSamplesText: {fileID: 461430149}
   scanDeviceDisplay: {fileID: 1505127163}

--- a/Assets/Scenes/Mission1.unity
+++ b/Assets/Scenes/Mission1.unity
@@ -316,7 +316,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh19002
+  m_Name: pb_Mesh32894
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -6030,98 +6030,6 @@ ParticleSystem:
         m_PostInfinity: 2
         m_RotationOrder: 4
     vectorLabel1_3: W
---- !u!1 &117780856
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 117780857}
-  - component: {fileID: 117780859}
-  - component: {fileID: 117780858}
-  m_Layer: 0
-  m_Name: SampleTestText
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &117780857
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 117780856}
-  m_LocalRotation: {x: 0.23091601, y: -0.020641023, z: -0.0048999456, w: 0.9727424}
-  m_LocalPosition: {x: -0.042691316, y: 0.03984375, z: 0.021942725}
-  m_LocalScale: {x: 0.0027467741, y: 0.0028564874, z: 0.003753449}
-  m_Children: []
-  m_Father: {fileID: 1348592516}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 26.682001, y: -2.7210002, z: -1.223}
---- !u!102 &117780858
-TextMesh:
-  serializedVersion: 3
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 117780856}
-  m_Text: Samples in area
-  m_OffsetZ: 0
-  m_CharacterSize: 1
-  m_LineSpacing: 1
-  m_Anchor: 0
-  m_Alignment: 0
-  m_TabSize: 4
-  m_FontSize: 0
-  m_FontStyle: 0
-  m_RichText: 1
-  m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-  m_Color:
-    serializedVersion: 2
-    rgba: 4294967295
---- !u!23 &117780859
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 117780856}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10100, guid: 0000000000000000e000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
 --- !u!1 &139059888 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: -1798063490283927114, guid: f46dca9c9cda6b2438817ac5976db1e3,
@@ -13666,98 +13574,6 @@ MeshCollider:
   m_Convex: 0
   m_CookingOptions: 14
   m_Mesh: {fileID: 4150410264870081745, guid: f46dca9c9cda6b2438817ac5976db1e3, type: 3}
---- !u!1 &461430147
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 461430148}
-  - component: {fileID: 461430150}
-  - component: {fileID: 461430149}
-  m_Layer: 0
-  m_Name: SampleCount
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &461430148
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 461430147}
-  m_LocalRotation: {x: 0.23091601, y: -0.020641023, z: -0.0048999456, w: 0.9727424}
-  m_LocalPosition: {x: -0.02993, y: 0.0296875, z: 0.017053}
-  m_LocalScale: {x: 0.0051993686, y: 0.005407045, z: 0.007104904}
-  m_Children: []
-  m_Father: {fileID: 1348592516}
-  m_RootOrder: 4
-  m_LocalEulerAnglesHint: {x: 26.682001, y: -2.7210002, z: -1.223}
---- !u!102 &461430149
-TextMesh:
-  serializedVersion: 3
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 461430147}
-  m_Text: 0
-  m_OffsetZ: 0
-  m_CharacterSize: 1
-  m_LineSpacing: 1
-  m_Anchor: 4
-  m_Alignment: 1
-  m_TabSize: 4
-  m_FontSize: 0
-  m_FontStyle: 0
-  m_RichText: 1
-  m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-  m_Color:
-    serializedVersion: 2
-    rgba: 4294967295
---- !u!23 &461430150
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 461430147}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10100, guid: 0000000000000000e000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
 --- !u!1 &465155351
 GameObject:
   m_ObjectHideFlags: 0
@@ -14922,7 +14738,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh24960
+  m_Name: pb_Mesh34072
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -20135,7 +19951,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh23756
+  m_Name: pb_Mesh32864
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -21976,7 +21792,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh19466
+  m_Name: pb_Mesh33368
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -23489,6 +23305,209 @@ MeshCollider:
   m_Convex: 0
   m_CookingOptions: 14
   m_Mesh: {fileID: 6802232616592832306, guid: d479326d256e0fd40ac5546cd7a8f4b6, type: 3}
+--- !u!1 &945841322
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 945841323}
+  - component: {fileID: 945841327}
+  - component: {fileID: 945841326}
+  - component: {fileID: 945841325}
+  - component: {fileID: 945841324}
+  m_Layer: 0
+  m_Name: Samples In Area Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &945841323
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 945841322}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0.01}
+  m_LocalScale: {x: 0.03, y: 0.03, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1348592516}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0.199, y: -0.026}
+  m_SizeDelta: {x: 20, y: 5}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &945841324
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 945841322}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9541d86e2fd84c1d9990edf0852d74ab, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Samples In Area
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_outlineColor:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontSize: 1
+  m_fontSizeBase: 1
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_textAlignment: 257
+  m_characterSpacing: 2
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_firstOverflowCharacterIndex: -1
+  m_linkedTextComponent: {fileID: 0}
+  m_isLinkedTextComponent: 0
+  m_isTextTruncated: 0
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 0
+  m_isCullingEnabled: 0
+  m_ignoreRectMaskCulling: 0
+  m_ignoreCulling: 1
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_VertexBufferAutoSizeReduction: 1
+  m_firstVisibleCharacter: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 1.7585688, y: 0, z: -57.388855, w: 4.872436}
+  m_textInfo:
+    textComponent: {fileID: 945841324}
+    characterCount: 15
+    spriteCount: 0
+    spaceCount: 2
+    wordCount: 3
+    linkCount: 0
+    lineCount: 1
+    pageCount: 1
+    materialCount: 1
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_spriteAnimator: {fileID: 0}
+  m_hasFontAssetChanged: 0
+  m_renderer: {fileID: 945841327}
+  m_subTextObjects:
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  m_maskType: 0
+--- !u!222 &945841325
+CanvasRenderer:
+  m_ObjectHideFlags: 2
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 945841322}
+  m_CullTransparentMesh: 0
+--- !u!33 &945841326
+MeshFilter:
+  m_ObjectHideFlags: 2
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 945841322}
+  m_Mesh: {fileID: 0}
+--- !u!23 &945841327
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 945841322}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
 --- !u!43 &946866323
 Mesh:
   m_ObjectHideFlags: 0
@@ -25204,8 +25223,8 @@ BoxCollider:
   m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 46, y: 15, z: 36.000004}
-  m_Center: {x: 23, y: 7.5, z: -18.00049}
+  m_Size: {x: 46, y: 15, z: 52.91327}
+  m_Center: {x: 23, y: 7.5, z: -9.543775}
 --- !u!114 &1041846805
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -25482,7 +25501,7 @@ MonoBehaviour:
   displayScanDevice: 1
   scanAreaTextToDisplay: Landing Site
   scanDevice: {fileID: 1348592515}
-  remainingSamplesText: {fileID: 461430149}
+  remainingSamplesText: {fileID: 2028319507}
   scanDeviceDisplay: {fileID: 1505127163}
 --- !u!1 &1043259336
 GameObject:
@@ -26388,9 +26407,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   displayScanDevice: 1
-  scanAreaTextToDisplay: Example Area
+  scanAreaTextToDisplay: Temple
   scanDevice: {fileID: 1348592515}
-  remainingSamplesText: {fileID: 461430149}
+  remainingSamplesText: {fileID: 0}
   scanDeviceDisplay: {fileID: 1505127163}
 --- !u!65 &1115351874
 BoxCollider:
@@ -32182,7 +32201,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh18894
+  m_Name: pb_Mesh32786
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -32505,7 +32524,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh18716
+  m_Name: pb_Mesh32614
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -34414,7 +34433,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh24452
+  m_Name: pb_Mesh33562
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -37174,7 +37193,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh19478
+  m_Name: pb_Mesh33380
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -38821,8 +38840,8 @@ BoxCollider:
   m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 31, y: 16, z: 30}
-  m_Center: {x: 26.5, y: 8, z: -21}
+  m_Size: {x: 30.999994, y: 16, z: 16.62561}
+  m_Center: {x: 26.499998, y: 8, z: -14.312805}
 --- !u!114 &1796003610
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -39035,17 +39054,9 @@ MonoBehaviour:
   m_PreserveMeshAssetOnDestroy: 0
   assetGuid: 
   m_IsSelectable: 1
-  m_SelectedFaces: 01000000
-  m_SelectedEdges:
-  - a: 4
-    b: 5
-  - a: 6
-    b: 4
-  - a: 5
-    b: 7
-  - a: 7
-    b: 6
-  m_SelectedVertices: 04000000050000000600000007000000
+  m_SelectedFaces: 
+  m_SelectedEdges: []
+  m_SelectedVertices: 
 --- !u!23 &1796003611
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -39107,7 +39118,7 @@ MonoBehaviour:
   displayScanDevice: 1
   scanAreaTextToDisplay: Maze Area
   scanDevice: {fileID: 1348592515}
-  remainingSamplesText: {fileID: 461430149}
+  remainingSamplesText: {fileID: 2028319507}
   scanDeviceDisplay: {fileID: 1505127163}
 --- !u!1 &1797792766
 GameObject:
@@ -39908,9 +39919,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   displayScanDevice: 0
-  scanAreaTextToDisplay: Example Area
+  scanAreaTextToDisplay: Lab HUB
   scanDevice: {fileID: 1348592515}
-  remainingSamplesText: {fileID: 461430149}
+  remainingSamplesText: {fileID: 2028319507}
   scanDeviceDisplay: {fileID: 1505127163}
 --- !u!65 &1877903993
 BoxCollider:
@@ -47466,7 +47477,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh19356
+  m_Name: pb_Mesh33258
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -52610,6 +52621,209 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2019787480}
   m_Mesh: {fileID: -6737709997319792712, guid: 0933e70225592f945a222875135b16cb, type: 3}
+--- !u!1 &2028319505
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2028319506}
+  - component: {fileID: 2028319510}
+  - component: {fileID: 2028319509}
+  - component: {fileID: 2028319508}
+  - component: {fileID: 2028319507}
+  m_Layer: 0
+  m_Name: Samples Left Count
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2028319506
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2028319505}
+  m_LocalRotation: {x: 0.04112628, y: 0.00000011175868, z: 0.007251667, w: 0.9991277}
+  m_LocalPosition: {x: 0, y: 0, z: -0.00790569}
+  m_LocalScale: {x: 0.03, y: 0.03, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1348592516}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 4.714, y: 0.034, z: 0.83300006}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0.2335, y: -0.028}
+  m_SizeDelta: {x: 20, y: 5}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2028319507
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2028319505}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9541d86e2fd84c1d9990edf0852d74ab, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 0
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_outlineColor:
+    serializedVersion: 2
+    rgba: 4278190080
+  m_fontSize: 3
+  m_fontSizeBase: 3
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_textAlignment: 257
+  m_characterSpacing: 2
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_firstOverflowCharacterIndex: 0
+  m_linkedTextComponent: {fileID: 0}
+  m_isLinkedTextComponent: 0
+  m_isTextTruncated: 0
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 0
+  m_isCullingEnabled: 0
+  m_ignoreRectMaskCulling: 0
+  m_ignoreCulling: 1
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_VertexBufferAutoSizeReduction: 1
+  m_firstVisibleCharacter: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 1.0165585, y: 0, z: -57.388855, w: 4.872436}
+  m_textInfo:
+    textComponent: {fileID: 2028319507}
+    characterCount: 1
+    spriteCount: 0
+    spaceCount: 0
+    wordCount: 1
+    linkCount: 0
+    lineCount: 1
+    pageCount: 1
+    materialCount: 1
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_spriteAnimator: {fileID: 0}
+  m_hasFontAssetChanged: 0
+  m_renderer: {fileID: 2028319510}
+  m_subTextObjects:
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}
+  m_maskType: 0
+--- !u!222 &2028319508
+CanvasRenderer:
+  m_ObjectHideFlags: 2
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2028319505}
+  m_CullTransparentMesh: 0
+--- !u!33 &2028319509
+MeshFilter:
+  m_ObjectHideFlags: 2
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2028319505}
+  m_Mesh: {fileID: 0}
+--- !u!23 &2028319510
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2028319505}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
 --- !u!1 &2034467375 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: -1387002046379115535, guid: f46dca9c9cda6b2438817ac5976db1e3,
@@ -52656,7 +52870,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh18396
+  m_Name: pb_Mesh32276
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -53991,7 +54205,7 @@ MonoBehaviour:
   displayScanDevice: 1
   scanAreaTextToDisplay: Forest
   scanDevice: {fileID: 1348592515}
-  remainingSamplesText: {fileID: 461430149}
+  remainingSamplesText: {fileID: 2028319507}
   scanDeviceDisplay: {fileID: 1505127163}
 --- !u!1 &2143971587 stripped
 GameObject:
@@ -54019,7 +54233,7 @@ Mesh:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: pb_Mesh18868
+  m_Name: pb_Mesh32760
   serializedVersion: 10
   m_SubMeshes:
   - serializedVersion: 2
@@ -54416,6 +54630,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: MissionSelectCanvas
+      objectReference: {fileID: 0}
+    - target: {fileID: 3820193021293416361, guid: 110eb9b684f1f86478fc2012ce429f97,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8051489197933246706, guid: 110eb9b684f1f86478fc2012ce429f97,
         type: 3}
@@ -55043,6 +55262,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_IsActive
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 730880382986759124, guid: c658493f6cc5270468b3cd30f47e8842,
+        type: 3}
+      propertyPath: m_Text
+      value: 
       objectReference: {fileID: 0}
     - target: {fileID: 4219846748226630893, guid: c658493f6cc5270468b3cd30f47e8842,
         type: 3}

--- a/Assets/Scripts/ItemEvents.cs
+++ b/Assets/Scripts/ItemEvents.cs
@@ -63,6 +63,8 @@ public class ItemEvents : MonoBehaviour
     public static bool obtainedGardenKeycard = false;
     public static bool obtainedInteriorLabKeycard = false;
 
+    public System.Action OnPickup; // Observer Pattern. When obj is picked up, SCANArea picks it up.
+
     private void Start()
     {
         this.tag = "Pickup";
@@ -203,6 +205,9 @@ public class ItemEvents : MonoBehaviour
             interactText.text = "";
             berryAmount += 1;
         }
+
+        OnPickup?.Invoke(); // Null check before notifying subscribers. 
+
         //else if (gameObject == keycardTrigger1)
         //{
         //    //obtainedInteriorLabKeycard = true;

--- a/Assets/Scripts/ItemEvents.cs
+++ b/Assets/Scripts/ItemEvents.cs
@@ -41,6 +41,7 @@ public class ItemEvents : MonoBehaviour
     public GameObject mushroom3;
     public GameObject mushroom4;
     public GameObject mushroom5;
+    public GameObject berry1;
 
 	//public GameObject keycard1;
 	//public GameObject keycard2;
@@ -54,6 +55,7 @@ public class ItemEvents : MonoBehaviour
 	//public GameObject MushroomAmount;
 	public static int mushroomAmount = 0;
     public static int keycardAmount = 0;
+    public static int berryAmount = 0;
 
     //public GameObject guardianKeycard;
     public static bool obtainedGuardianKeycard = false;
@@ -194,6 +196,13 @@ public class ItemEvents : MonoBehaviour
             Destroy(mushroomTrigger5);
             mushroomAmount += 1;
         }
+        else if (gameObject == berry1)
+        {
+            audio.Play();
+            Destroy(this.gameObject);
+            interactText.text = "";
+            berryAmount += 1;
+        }
         //else if (gameObject == keycardTrigger1)
         //{
         //    //obtainedInteriorLabKeycard = true;
@@ -202,7 +211,7 @@ public class ItemEvents : MonoBehaviour
         //    Destroy(keycardTrigger1);
         //    keycardAmount += 1;
         //    //obtainedInteriorLabKecard = true;
-            
+
         //}
         //else if (gameObject == keycardTrigger2)
         //{
@@ -212,7 +221,7 @@ public class ItemEvents : MonoBehaviour
         //    Destroy(keycardTrigger2);
         //    keycardAmount += 1;
         //    //obtainedGardenKeycard = true;
-            
+
         //}
     }
 

--- a/Assets/Scripts/SCANarea.cs
+++ b/Assets/Scripts/SCANarea.cs
@@ -23,7 +23,7 @@ public class SCANarea : MonoBehaviour
 		if (other.CompareTag("Pickup"))
 		{
 			numberOfCollectiblesInArea++; // Dynamically sets how many pickups in this area TODO Won't decrement
-			other.gameObject.GetComponent<ItemEvents>().OnPickup += OnItemPickup();
+			other.gameObject.GetComponent<ItemEvents>().OnPickup += OnItemPickup;
 		}
 
 		if (other.CompareTag("Player"))
@@ -42,6 +42,12 @@ public class SCANarea : MonoBehaviour
 		}
 	}
 
+	private void OnItemPickup()
+	{
+		numberOfCollectiblesInArea--;
+		UpdateItemsLeftText();
+	}
+
 	private void OnTriggerExit(Collider other)
 	{
 		if (other.CompareTag("Player"))
@@ -49,13 +55,6 @@ public class SCANarea : MonoBehaviour
 			scanDevice.SetActive(false);
 			scanDeviceDisplay.text = "";
 			remainingSamplesText.text = "";
-		}
-		
-		if (other.CompareTag("Pickup"))
-		{
-			Debug.Log("dwdwdw");
-			numberOfCollectiblesInArea--;
-			UpdateItemsLeftText();
 		}
 	}
 

--- a/Assets/Scripts/SCANarea.cs
+++ b/Assets/Scripts/SCANarea.cs
@@ -11,7 +11,7 @@ public class SCANarea : MonoBehaviour
 	[SerializeField]
 	private GameObject scanDevice;
 	[SerializeField]
-	private TextMesh remainingSamplesText;
+	private TMPro.TextMeshPro remainingSamplesText;
 
 	[SerializeField]
 	private Text scanDeviceDisplay;
@@ -28,13 +28,14 @@ public class SCANarea : MonoBehaviour
 
 		if (other.CompareTag("Player"))
 		{
+			scanDeviceDisplay.text = scanAreaTextToDisplay;
 			UpdateItemsLeftText();
 
 			if (displayScanDevice)
 			{
-				scanDevice.SetActive(true);
-				scanDeviceDisplay.text = scanAreaTextToDisplay;
+				scanDevice.SetActive(true);				
 			}
+
 			else
 			{
 				scanDevice.SetActive(false);
@@ -46,16 +47,6 @@ public class SCANarea : MonoBehaviour
 	{
 		numberOfCollectiblesInArea--;
 		UpdateItemsLeftText();
-	}
-
-	private void OnTriggerExit(Collider other)
-	{
-		if (other.CompareTag("Player"))
-		{
-			scanDevice.SetActive(false);
-			scanDeviceDisplay.text = "";
-			remainingSamplesText.text = "";
-		}
 	}
 
 	private void UpdateItemsLeftText()

--- a/Assets/Scripts/SCANarea.cs
+++ b/Assets/Scripts/SCANarea.cs
@@ -5,32 +5,9 @@ using UnityEngine.UI;
 
 public class SCANarea : MonoBehaviour
 {
-	#region triggerboxes
-	[SerializeField]
-	private GameObject courtyardTrigger;
-	[SerializeField]
-	private GameObject mazeTrigger;
-	[SerializeField]
-	private GameObject forestTrigger;
-	[SerializeField]
-	private GameObject labHUBTrigger;
-	[SerializeField]
-	private GameObject templeInteriorTrigger;
-	#endregion
-
-	#region booleanChecklist
-	[SerializeField]
-	private bool isInCourtyard;
-	[SerializeField]
-	private bool isInMaze;
-	[SerializeField]
-	private bool isInForest;
-	[SerializeField]
-	private bool isInLabHUB;
-	[SerializeField]
-	private bool isInTemple;
-	#endregion
-
+	[SerializeField] private bool displayScanDevice = true;
+	[SerializeField] private string scanAreaTextToDisplay = "Example Area";
+ 
 	[SerializeField]
 	private GameObject scanDevice;
 	[SerializeField]
@@ -39,33 +16,51 @@ public class SCANarea : MonoBehaviour
 	[SerializeField]
 	private Text scanDeviceDisplay;
 
+	private int numberOfCollectiblesInArea = 0;
+
 	private void OnTriggerEnter(Collider other)
 	{
-		if (isInCourtyard == true && isInMaze == false && isInForest == false && isInLabHUB == false && isInTemple == false)
+		if (other.CompareTag("Pickup"))
 		{
-			scanDevice.SetActive(true);
-			scanDeviceDisplay.text = "Courtyard";
-			remainingSamplesText.text = "0";
+			numberOfCollectiblesInArea++; // Dynamically sets how many pickups in this area TODO Won't decrement
+			other.gameObject.GetComponent<ItemEvents>().OnPickup += OnItemPickup();
 		}
-		else if (isInCourtyard == false && isInMaze == true && isInForest == false && isInLabHUB == false && isInTemple == false)
+
+		if (other.CompareTag("Player"))
 		{
-			scanDeviceDisplay.text = "Hedge Maze";
-			remainingSamplesText.text = "2";
+			UpdateItemsLeftText();
+
+			if (displayScanDevice)
+			{
+				scanDevice.SetActive(true);
+				scanDeviceDisplay.text = scanAreaTextToDisplay;
+			}
+			else
+			{
+				scanDevice.SetActive(false);
+			}
 		}
-		else if (isInCourtyard == false && isInMaze == false && isInForest == true && isInLabHUB == false && isInTemple == false)
-		{
-			scanDeviceDisplay.text = "Forest";
-			remainingSamplesText.text = "1";
-		}
-		else if (isInCourtyard == false && isInMaze == false && isInForest == false && isInLabHUB == true && isInTemple == false)
+	}
+
+	private void OnTriggerExit(Collider other)
+	{
+		if (other.CompareTag("Player"))
 		{
 			scanDevice.SetActive(false);
-			scanDeviceDisplay.text = "Lab HUB";
+			scanDeviceDisplay.text = "";
+			remainingSamplesText.text = "";
 		}
-		else if (isInCourtyard == false && isInMaze == false && isInForest == false && isInLabHUB == false && isInTemple == true)
+		
+		if (other.CompareTag("Pickup"))
 		{
-			scanDeviceDisplay.text = "Temple";
-			remainingSamplesText.text = "1";
+			Debug.Log("dwdwdw");
+			numberOfCollectiblesInArea--;
+			UpdateItemsLeftText();
 		}
+	}
+
+	private void UpdateItemsLeftText()
+	{
+		remainingSamplesText.text = numberOfCollectiblesInArea.ToString();
 	}
 }


### PR DESCRIPTION
This branch:
- Makes it so each SCAN area samples left value is dynamically set at runtime based on how many pickups are in each area. (How many "pickup" items are in each area's trigger box.)
- When the items are picked up, this value is decremented accordingly.
- The text for "Samples Left" and value were replaced so the text is properly anti-aliased.  